### PR TITLE
feat: full sync on plugin initialisation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,29 @@ and default to
 }
 ```
 
+### Full synchronise on start with initialState as default
+
+Since version 0.4.0 this module allows full state synchronisation with cookies, localstorage and initialstate as a default value. That allows for a very neat usage pattern:
+For example, if I have an initialState like the following in Nuxt config:
+
+```
+  storage: {
+    initialState: { testParam: false }
+  }
+```
+then in my component I can simply declare (with decorators)
+```
+  @State(s => s.storage.testParam)
+  testParam
+```  
+or  (with mapState)
+```
+  computed: mapState({
+    testParam: s => s.storage.testParam
+    })
+```    
+then I get computed property `testParam` with whatever value it had on my last session and on change I just fire `this.$storage.setUniversal("testParam", newVal)` to get value saved
+
 ### Api 
   
 * `$storage.getUniversal(key)`

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,15 +1,11 @@
 import Storage from './storage'
-import { serialize } from 'uri-js';
 
 export default function nuxtUniversalStorage(ctx, inject) {
-  const options=<%= JSON.stringify(options, null, 2) %>
+  const options = <%= JSON.stringify(options, null, 2) %>
+
   // Create new instance of Storage class
   const storage = new Storage(ctx, options)
 
-  // Synchronise initial values
-  for(let key in options.initialState) {
-  storage.syncUniversal(key, options.initialState[key])
-  }
   // Inject into context as $storage
   inject('storage', storage)
 }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -6,9 +6,9 @@ export default function nuxtUniversalStorage(ctx, inject) {
   // Create new instance of Storage class
   const storage = new Storage(ctx, options)
 
-// Synchronise initial values
+  // Synchronise initial values
   for(let key in options.initialState) {
-	storage.syncUniversal(key, options.initialState[key])
+  storage.syncUniversal(key, options.initialState[key])
   }
   // Inject into context as $storage
   inject('storage', storage)

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -2,9 +2,14 @@ import Storage from './storage'
 import { serialize } from 'uri-js';
 
 export default function nuxtUniversalStorage(ctx, inject) {
+  const options=<%= JSON.stringify(options, null, 2) %>
   // Create new instance of Storage class
-  const storage = new Storage(ctx, <%= JSON.stringify(options, null, 2) %>)
+  const storage = new Storage(ctx, options)
 
+// Synchronise initial values
+  for(let key in options.initialState) {
+	storage.syncUniversal(key, options.initialState[key])
+  }
   // Inject into context as $storage
   inject('storage', storage)
 }

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -9,7 +9,7 @@ export default class Storage {
     this.ctx = ctx
     this.options = options
 
-    this._initState()
+    this._initState(options.initialState)
   }
 
   // ------------------------------------
@@ -70,7 +70,7 @@ export default class Storage {
   // Local state (reactive)
   // ------------------------------------
 
-  _initState () {
+  _initState (initData) {
     // Private state is suitable to keep information not being exposed to Vuex store
     // This helps prevent stealing token from SSR response HTML
     Vue.set(this, '_state', {})
@@ -81,6 +81,7 @@ export default class Storage {
     if (this._useVuex) {
       const storeModule = {
         namespaced: true,
+        state: () => {},
         mutations: {
           SET (state, payload) {
             Vue.set(state, payload.key, payload.value)
@@ -95,6 +96,11 @@ export default class Storage {
       this.state = this.ctx.store.state[this.options.vuex.namespace]
     } else {
       Vue.set(this, 'state', {})
+    }
+
+    // Synchronise initial values
+    for(let key in initData) {
+      this.syncUniversal(key, initData[key])
     }
   }
 

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -81,7 +81,6 @@ export default class Storage {
     if (this._useVuex) {
       const storeModule = {
         namespaced: true,
-        state: () => this.options.initialState,
         mutations: {
           SET (state, payload) {
             Vue.set(state, payload.key, payload.value)

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -81,7 +81,7 @@ export default class Storage {
     if (this._useVuex) {
       const storeModule = {
         namespaced: true,
-        state: () => {},
+        state: () => ({}),
         mutations: {
           SET (state, payload) {
             Vue.set(state, payload.key, payload.value)


### PR DESCRIPTION
Full synchronise on start with initialState

I like this library for it's simplicity, but I stumbled on a frustrating issue. Basically, there is an issue with current initial state. Currently it is pretty much useless as it ignores the values in cookies and localstorage. Instead I needed to run full sync on initialization.

This change achieves the objective. Now we run `syncUniversal` for every key in `initialState` on plugin registration.

That allows for very neat usage pattern:
For example, if I have an initialState like the following in nuxt config:
```js
  storage: {
    initialState: { testParam: false }
  },
```
then in my component (with decorators) I can simply declare
```js
  @State(s => s.storage.testParam)
  testParam
```
then I get computed property `testParam` with whatever value it had on my last session and on change I just fire `this.$storage.setUniversal("testParam", newVal)` to get value saved