### PR TITLE
Generate mode local state issue

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -32,7 +32,6 @@ export default class Storage {
   getUniversal (key) {
     // Local state
     let value
-    // let value = this.getState(key)
 
     // Cookies
     if (isUnset(value)) {
@@ -121,14 +120,6 @@ export default class Storage {
 
     return value
   }
-
-  // getState (key) {
-  //   if (key[0] !== '_') {
-  //     return this.state[key]
-  //   } else {
-  //     return this._state[key]
-  //   }
-  // }
 
   watchState (key, fn) {
     if (this._useVuex) {

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -32,7 +32,7 @@ export default class Storage {
   getUniversal (key) {
     // Local state
     let value
-    if (process.dev || !process.static) {
+    if (!process.static) {
       // issue #76
       value = this.getState(key)
     }

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -31,7 +31,8 @@ export default class Storage {
 
   getUniversal (key) {
     // Local state
-    let value = this.getState(key)
+    let value
+    // let value = this.getState(key)
 
     // Cookies
     if (isUnset(value)) {
@@ -121,13 +122,13 @@ export default class Storage {
     return value
   }
 
-  getState (key) {
-    if (key[0] !== '_') {
-      return this.state[key]
-    } else {
-      return this._state[key]
-    }
-  }
+  // getState (key) {
+  //   if (key[0] !== '_') {
+  //     return this.state[key]
+  //   } else {
+  //     return this._state[key]
+  //   }
+  // }
 
   watchState (key, fn) {
     if (this._useVuex) {

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -32,6 +32,10 @@ export default class Storage {
   getUniversal (key) {
     // Local state
     let value
+    if (!process.static) {
+      // issue #76
+      value = this.getState(key)
+    }
 
     // Cookies
     if (isUnset(value)) {
@@ -119,6 +123,14 @@ export default class Storage {
     }
 
     return value
+  }
+
+  getState (key) {
+    if (key[0] !== '_') {
+      return this.state[key]
+    } else {
+      return this._state[key]
+    }
   }
 
   watchState (key, fn) {

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -32,7 +32,7 @@ export default class Storage {
   getUniversal (key) {
     // Local state
     let value
-    if (!process.static) {
+    if (process.dev || !process.static) {
       // issue #76
       value = this.getState(key)
     }


### PR DESCRIPTION
Fixes https://github.com/nuxt-community/universal-storage-module/issues/75

`getState` is always return `undefined` in development. And when running in prod in generate mode, `getState` returns `initialState` instead of actual saved local state in cookies or local storage (module ignores cookie or storage since `getState` return an actual value), which leads to overwriting of local session state.