### PR TITLE
Add tabSync option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Options are defined as following:
 ```js
  storage: {
   vuex, // boolean or {namespace}
-  localStorage, // boolean or {prefix }
+  localStorage, // boolean or {prefix, tabSync }
   cookie, // boolean or {prefix, options }
   initialState,  // Object {}
   ignoreExceptions //
@@ -69,7 +69,8 @@ and default to the following values:
     }
   },
   localStorage: {
-    prefix: ''
+    prefix: '',
+    tabSync: true
   },
   ignoreExceptions: false,
 }
@@ -125,6 +126,10 @@ For example:
 - `$storage.syncUniversal(key, defaultValue)`
 
 - `$storage.removeUniversal(key)`
+
+- `$storage.enableTabTrack(key)`
+
+- `$storage.disableTabTrack(key)`
 
 - `$storage.getState(key)`
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -11,7 +11,8 @@ const defaults = {
     }
   },
   localStorage: {
-    prefix: ''
+    prefix: '',
+    tabSync: true
   },
   ignoreExceptions: false
 }

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -155,7 +155,9 @@ export default class Storage {
     window.addEventListener('storage', () => {
       this.trackTabKeys.forEach(key => {
         const value = this.getLocalStorage(key)
-        this.setUniversal(key, value)
+        if (isSet(value)) {
+          this.setUniversal(key, this.getLocalStorage(key))
+        }
       })
     })
   }

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -8,8 +8,10 @@ export default class Storage {
   constructor (ctx, options) {
     this.ctx = ctx
     this.options = options
+    this.trackTabKeys = []
 
     this._initState(options.initialState)
+    this._initTabSync()
   }
 
   // ------------------------------------
@@ -145,6 +147,29 @@ export default class Storage {
   // ------------------------------------
   // Local storage
   // ------------------------------------
+
+  _initTabSync () {
+    if (typeof localStorage === 'undefined' || !this.options.localStorage || !this.options.localStorage.tabSync || !process.client) {
+      return
+    }
+    window.addEventListener('storage', () => {
+      this.trackTabKeys.forEach(key => {
+        const value = this.getLocalStorage(key)
+        this.setUniversal(key, value)
+      })
+    })
+  }
+
+  enableTabTrack (key) {
+    this.trackTabKeys.push(key)
+  }
+
+  disableTabTrack (key) {
+    const i = this.trackTabKeys.indexOf(key)
+    if (i >= 0) {
+      this.trackTabKeys.splice(i, 1)
+    }
+  }
 
   setLocalStorage (key, value) {
     if (typeof localStorage === 'undefined' || !this.options.localStorage) {


### PR DESCRIPTION
hi
i add tab sync option with [storage event](https://developer.mozilla.org/en-US/docs/Web/API/Window/storage_event)

### how to use?

1. initial your key data (like with syncUniversal method).
2. next enable track your key with **enableTabTrack** method.
3. you can disable track key with **disableTabTrack**
4. now your key sync in all tabs in your browser

### example:

```js
this.keyname = 'appAuthorize';

// initial data
this.$storage.syncUniversal(this.keyname , {
    login: false,
    token: '',
    ...
);

// enable key track
this.$storage.enableTabTrack(this.keyname );
```

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8210666/77592151-2d189600-6f0f-11ea-923a-1c39c64a0946.gif)
