### PR TITLE
fix: set-cookie should be an array

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -215,7 +215,7 @@ export default class Storage {
       document.cookie = serializedCookie
     } else if (process.server && this.ctx.res) {
       // Send Set-Cookie header from server side
-      this.ctx.res.setHeader('Set-Cookie', serializedCookie)
+      this.ctx.res.setHeader('Set-Cookie', [serializedCookie])
     }
 
     return value


### PR DESCRIPTION
Or otherwise it will break with nuxt-auth module or any other module that will want to modify set-cookie and expect array there not a string.
https://nodejs.org/api/http.html#http_request_getheader_name