### PR TITLE
docs: add types configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ npm install @nuxtjs/universal-storage --save
 }
 ```
 
+## TypeScript
+
+Add the types to your "types" array in `tsconfig.json`
+
+```json
+{
+  "compilerOptions": {
+    "types": [
+      "@nuxt/types",
+      "@nuxtjs/universal-storage"
+    ]
+  }
+}
+```
+
 ## Usage
 
 ### Options


### PR DESCRIPTION
I was using this module with typescript and I realized that the types exist and can be used correctly but they are not in the documentation.